### PR TITLE
Pass cache instance into reconcilers directly

### DIFF
--- a/controllers/dynamicclusterrole_controller.go
+++ b/controllers/dynamicclusterrole_controller.go
@@ -39,6 +39,7 @@ type DynamicClusterRoleReconciler struct {
 	client.Client
 	Log    logr.Logger
 	Scheme *runtime.Scheme
+	Cache  *helpers.ResourceCache
 }
 
 // +kubebuilder:rbac:groups=rbac.redhatcop.redhat.io,resources=dynamicclusterroles,verbs=get;list;watch;create;update;patch;delete
@@ -59,11 +60,11 @@ func (r *DynamicClusterRoleReconciler) Reconcile(req ctrl.Request) (ctrl.Result,
 		return reconcile.Result{}, err
 	}
 
-	return ReconcileDynamicClusterRole(instance, r.Client, r.Scheme, r.Log)
+	return ReconcileDynamicClusterRole(instance, r.Client, r.Scheme, r.Log, r.Cache)
 }
 
-func ReconcileDynamicClusterRole(dynamicClusterRole *rbacv1alpha1.DynamicClusterRole, client client.Client, scheme *runtime.Scheme, logger logr.Logger) (ctrl.Result, error) {
-	rules, err := helpers.BuildPolicyRules(client, helpers.ClusterRole, "", dynamicClusterRole.Spec.Inherit, dynamicClusterRole.Spec.Allow, dynamicClusterRole.Spec.Deny)
+func ReconcileDynamicClusterRole(dynamicClusterRole *rbacv1alpha1.DynamicClusterRole, client client.Client, scheme *runtime.Scheme, logger logr.Logger, cache *helpers.ResourceCache) (ctrl.Result, error) {
+	rules, err := helpers.BuildPolicyRules(client, *cache, helpers.ClusterRole, "", dynamicClusterRole.Spec.Inherit, dynamicClusterRole.Spec.Allow, dynamicClusterRole.Spec.Deny)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/controllers/dynamicrole_controller.go
+++ b/controllers/dynamicrole_controller.go
@@ -39,6 +39,7 @@ type DynamicRoleReconciler struct {
 	client.Client
 	Log    logr.Logger
 	Scheme *runtime.Scheme
+	Cache  *helpers.ResourceCache
 }
 
 // +kubebuilder:rbac:groups=rbac.redhatcop.redhat.io,resources=dynamicroles,verbs=get;list;watch;create;update;patch;delete
@@ -59,11 +60,11 @@ func (r *DynamicRoleReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 		return reconcile.Result{}, err
 	}
 
-	return ReconcileDynamicRole(instance, r.Client, r.Scheme, r.Log)
+	return ReconcileDynamicRole(instance, r.Client, r.Scheme, r.Log, r.Cache)
 }
 
-func ReconcileDynamicRole(dynamicRole *rbacv1alpha1.DynamicRole, client client.Client, scheme *runtime.Scheme, logger logr.Logger) (ctrl.Result, error) {
-	rules, err := helpers.BuildPolicyRules(client, helpers.Role, dynamicRole.Namespace, dynamicRole.Spec.Inherit, dynamicRole.Spec.Allow, dynamicRole.Spec.Deny)
+func ReconcileDynamicRole(dynamicRole *rbacv1alpha1.DynamicRole, client client.Client, scheme *runtime.Scheme, logger logr.Logger, cache *helpers.ResourceCache) (ctrl.Result, error) {
+	rules, err := helpers.BuildPolicyRules(client, *cache, helpers.Role, dynamicRole.Namespace, dynamicRole.Spec.Inherit, dynamicRole.Spec.Allow, dynamicRole.Spec.Deny)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/main.go
+++ b/main.go
@@ -76,10 +76,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	cache := helpers.GetCacheInstance()
+
 	if err = (&controllers.CustomResourceDefinitionReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("CustomResourceDefinition"),
 		Scheme: mgr.GetScheme(),
+		Cache:  cache,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CustomResourceDefinition")
 		os.Exit(1)
@@ -88,6 +91,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("DynamicRole"),
 		Scheme: mgr.GetScheme(),
+		Cache:  cache,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DynamicRole")
 		os.Exit(1)
@@ -96,6 +100,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("DynamicClusterRole"),
 		Scheme: mgr.GetScheme(),
+		Cache:  cache,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DynamicClusterRole")
 		os.Exit(1)
@@ -104,7 +109,6 @@ func main() {
 
 	// Begin cache setup
 	setupLog.Info("Performing pre-controller setup")
-	cache := helpers.GetCacheInstance()
 	restConfig, err := ctrl.GetConfig()
 	if err != nil {
 		setupLog.Error(err, "could not instantiate a client for pre-controller setup processes")


### PR DESCRIPTION
Having it as a singleton was a quick way to proof it out but we should pass an instance to reconcilers instead of letting them get their own instance on-the-fly (better for adding testing soon).