### PR TITLE
Major implementation follow-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This operator can be installed with Kustomize:
 
 Once the operator is installed, you can begin using `DynamicRole` and `DynamicClusterRole` resources within your cluster.
 
-For example, the `DynamicClusterRole`:
+For example, the following `DynamicClusterRole` inherits all rules from `cluster-admin`, except the `user.openshift.io` group, and _only_ allows access to `pods` in the `metrics.k8s.io` group:
 
 ```yaml
 apiVersion: rbac.redhatcop.redhat.io/v1alpha1
@@ -63,7 +63,20 @@ spec:
     - apiGroups:
         - "user.openshift.io"
       resources:
-        - "users"
+        - "*"
+      verbs:
+        - "*"
+    - apiGroups:
+        - "metrics.k8s.io"
+      resources:
+        - "*"
+      verbs:
+        - "*"
+  allow:
+    - apiGroups:
+        - "metrics.k8s.io"
+      resources:
+        - "pods"
       verbs:
         - "*"
 ```
@@ -77,12 +90,6 @@ You can then create a `RoleBinding` or `ClusterRoleBinding` to `admin-without-us
 ## Roadmap
 
 See the [open issues](https://github.com/redhat-cop/dynamic-rbac-operator/issues) for a list of proposed features.
-
-## Known Issues
-
-1. Only one role can be inherited right now, even though it is spec'd as a list, because ruleset merging is still WIP.
-2. Allow lists are in the spec but not yet implemented, because of the same reason as above.
-3. This operator requires `cluster-admin` privileges, because it needs to be able to write RBAC rules that grant arbitrary permissions that it doesn't actually need itself. `make manifests` currently overwrites this.
 
 <!-- CONTRIBUTING -->
 

--- a/config/samples/rbac_v1alpha1_dynamicclusterrole.yaml
+++ b/config/samples/rbac_v1alpha1_dynamicclusterrole.yaml
@@ -13,3 +13,16 @@ spec:
         - "*"
       verbs:
         - "*"
+    - apiGroups:
+        - "metrics.k8s.io"
+      resources:
+        - "*"
+      verbs:
+        - "*"
+  allow:
+    - apiGroups:
+        - "metrics.k8s.io"
+      resources:
+        - "pods"
+      verbs:
+        - "*"

--- a/helpers/golang_type_helpers.go
+++ b/helpers/golang_type_helpers.go
@@ -1,5 +1,7 @@
 package helpers
 
+import "github.com/jinzhu/copier"
+
 func stringInSlice(slice []string, str string) bool {
 	for _, item := range slice {
 		if item == str {
@@ -30,4 +32,15 @@ func subtractStringSlices(allElements []string, elementsToRemove []string) []str
 		}
 	}
 	return newList
+}
+
+func appendSet(input []string, stringsToAppend ...string) []string {
+	output := []string{}
+	copier.Copy(&output, &input)
+	for _, s := range stringsToAppend {
+		if !stringInSlice(output, s) {
+			output = append(output, s)
+		}
+	}
+	return output
 }

--- a/helpers/policy_internal_representation.go
+++ b/helpers/policy_internal_representation.go
@@ -1,0 +1,56 @@
+package helpers
+
+import (
+	v1 "k8s.io/api/rbac/v1"
+)
+
+type expandedPolicyKey struct {
+	APIGroup        string
+	Resource        string
+	ResourceNames   string
+	NonResourceURLs string
+}
+
+type policyValue []string
+
+// PolicyListIR is an internal representation of a list of PolicyRules which is easier to patch and manipulate
+type policyListIR map[expandedPolicyKey]policyValue
+
+func policyListToIR(input []v1.PolicyRule) policyListIR {
+	outputMap := make(policyListIR)
+	for _, rule := range input {
+		currentPolicyKey := expandedPolicyKey{
+			APIGroup: rule.APIGroups[0],
+			Resource: rule.Resources[0],
+		}
+		if _, ok := outputMap[currentPolicyKey]; ok {
+			outputMap[currentPolicyKey] = appendSet(outputMap[currentPolicyKey], rule.Verbs...)
+		} else {
+			outputMap[currentPolicyKey] = rule.Verbs
+		}
+	}
+	return outputMap
+}
+
+func irToPolicyList(input policyListIR) []v1.PolicyRule {
+	output := make([]v1.PolicyRule, 0, 100)
+	for key, verbs := range input {
+		output = append(output, v1.PolicyRule{
+			APIGroups: []string{key.APIGroup},
+			Resources: []string{key.Resource},
+			Verbs:     verbs,
+		})
+	}
+	return output
+}
+
+func unionIRs(m1, m2 policyListIR) policyListIR {
+	for ia, va := range m1 {
+		if it, ok := m2[ia]; ok {
+			va = appendSet(va, it...)
+		}
+		m2[ia] = va
+
+	}
+	return m2
+}

--- a/helpers/rule_manipulation.go
+++ b/helpers/rule_manipulation.go
@@ -69,7 +69,7 @@ func BuildPolicyRules(client client.Client, cache ResourceCache, roleType RoleTy
 	}
 
 	if allow != nil {
-		allowRules, err := EnumeratePolicyRules(*allow)
+		allowRules, err := EnumeratePolicyRules(*allow, &cache)
 		if err != nil {
 			return nil, err
 		}

--- a/helpers/rule_manipulation.go
+++ b/helpers/rule_manipulation.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/jinzhu/copier"
 	"github.com/redhat-cop/dynamic-rbac-operator/api/v1alpha1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -26,10 +25,6 @@ func BuildPolicyRules(client client.Client, roleType RoleType, forNamespace stri
 	rules := []v1.PolicyRule{}
 
 	if inherit != nil {
-		if len(*inherit) != 1 {
-			// TODO: multi-role inheritance, merging policies, etc.
-			return nil, errors.New("this operator only supports one inherited role right now")
-		}
 		for _, roleToInherit := range *inherit {
 			switch roleToInherit.Kind {
 			case "ClusterRole":
@@ -47,7 +42,7 @@ func BuildPolicyRules(client client.Client, roleType RoleType, forNamespace stri
 					enumeratedPolicyRules, err = EnumeratePolicyRules(inheritedClusterRole.Rules)
 				}
 				expandedPolicyRules := ExpandPolicyRules(enumeratedPolicyRules)
-				rules = append(rules, expandedPolicyRules...)
+				rules = MergeExpandedPolicyRules(rules, expandedPolicyRules)
 			case "Role":
 				if roleType == ClusterRole && roleToInherit.Namespace == "" {
 					return nil, errors.New("a Cluster Role cannot inherit from a Role without a namespace specified")
@@ -64,7 +59,7 @@ func BuildPolicyRules(client client.Client, roleType RoleType, forNamespace stri
 				}
 				enumeratedPolicyRules, err := EnumeratePolicyRules(inheritedRole.Rules)
 				expandedPolicyRules := ExpandPolicyRules(enumeratedPolicyRules)
-				rules = append(rules, expandedPolicyRules...)
+				rules = MergeExpandedPolicyRules(rules, expandedPolicyRules)
 			}
 		}
 	}
@@ -73,17 +68,25 @@ func BuildPolicyRules(client client.Client, roleType RoleType, forNamespace stri
 		rules = ApplyDenyRulesToExpandedRuleset(rules, *deny)
 	}
 
+	if allow != nil {
+		allowRules, err := EnumeratePolicyRules(*allow)
+		if err != nil {
+			return nil, err
+		}
+		rules = MergeExpandedPolicyRules(rules, ExpandPolicyRules(allowRules))
+	}
+
 	return &rules, nil
 }
 
 // EnumeratePolicyRules takes a list of rules with wildcards and returns a list of policy rules with resources explicitly enumerated
-func EnumeratePolicyRules(inputRules []rbacv1.PolicyRule) ([]rbacv1.PolicyRule, error) {
-	rules := []rbacv1.PolicyRule{}
+func EnumeratePolicyRules(inputRules []v1.PolicyRule) ([]v1.PolicyRule, error) {
+	rules := []v1.PolicyRule{}
 	cache := GetCacheInstance()
 	allPossibleRules := cache.AllPolicies
 	for _, rule := range inputRules {
 		if ruleHasGroupWildcard(&rule) && ruleHasResourceWildcard(&rule) {
-			var relevantRules []rbacv1.PolicyRule
+			var relevantRules []v1.PolicyRule
 			copier.Copy(&relevantRules, allPossibleRules)
 			if !stringInSlice(rule.Verbs, "*") {
 				for index := range relevantRules {
@@ -95,9 +98,13 @@ func EnumeratePolicyRules(inputRules []rbacv1.PolicyRule) ([]rbacv1.PolicyRule, 
 			for _, resource := range rule.Resources {
 				for _, matchedRule := range *allPossibleRules {
 					if stringInSlice(matchedRule.Resources, resource) {
-						var tmpRule rbacv1.PolicyRule
+						var tmpRule v1.PolicyRule
 						copier.Copy(&tmpRule, &matchedRule)
-						copier.Copy(&tmpRule.Verbs, &rule.Verbs)
+						if !stringInSlice(rule.Verbs, "*") {
+							copier.Copy(&tmpRule.Verbs, &rule.Verbs)
+						} else {
+							copier.Copy(&tmpRule.Verbs, &matchedRule.Verbs)
+						}
 						rules = append(rules, tmpRule)
 					}
 				}
@@ -106,23 +113,45 @@ func EnumeratePolicyRules(inputRules []rbacv1.PolicyRule) ([]rbacv1.PolicyRule, 
 			for _, group := range rule.APIGroups {
 				for _, matchedRule := range *allPossibleRules {
 					if stringInSlice(matchedRule.APIGroups, group) {
-						var tmpRule rbacv1.PolicyRule
+						var tmpRule v1.PolicyRule
 						copier.Copy(&tmpRule, &matchedRule)
-						copier.Copy(&tmpRule.Verbs, &rule.Verbs)
+						if !stringInSlice(rule.Verbs, "*") {
+							copier.Copy(&tmpRule.Verbs, &rule.Verbs)
+						} else {
+							copier.Copy(&tmpRule.Verbs, &matchedRule.Verbs)
+						}
 						rules = append(rules, tmpRule)
 					}
 				}
 			}
 		} else {
-			rules = append(rules, rule)
+			for _, group := range rule.APIGroups {
+				if group == "v1" {
+					group = ""
+				}
+				for _, resource := range rule.Resources {
+					for _, matchedRule := range *allPossibleRules {
+						if stringInSlice(matchedRule.APIGroups, group) && stringInSlice(matchedRule.Resources, resource) {
+							var tmpRule v1.PolicyRule
+							copier.Copy(&tmpRule, &matchedRule)
+							if !stringInSlice(rule.Verbs, "*") {
+								copier.Copy(&tmpRule.Verbs, &rule.Verbs)
+							} else {
+								copier.Copy(&tmpRule.Verbs, &matchedRule.Verbs)
+							}
+							rules = append(rules, tmpRule)
+						}
+					}
+				}
+			}
 		}
 	}
 	return rules, nil
 }
 
 // ExpandPolicyRules ensures that multiple resources with the same verbs are not grouped together in the same rule definition (makes it easier to edit individual verbs later)
-func ExpandPolicyRules(inputRules []rbacv1.PolicyRule) []rbacv1.PolicyRule {
-	rules := []rbacv1.PolicyRule{}
+func ExpandPolicyRules(inputRules []v1.PolicyRule) []v1.PolicyRule {
+	rules := []v1.PolicyRule{}
 	for _, rule := range inputRules {
 		if len(rule.Resources) > 1 {
 			for _, resource := range rule.Resources {
@@ -130,7 +159,7 @@ func ExpandPolicyRules(inputRules []rbacv1.PolicyRule) []rbacv1.PolicyRule {
 				var newAPIGroups []string
 				copier.Copy(&newVerbs, &rule.Verbs)
 				copier.Copy(&newAPIGroups, &rule.APIGroups)
-				newRule := rbacv1.PolicyRule{
+				newRule := v1.PolicyRule{
 					APIGroups: newAPIGroups,
 					Resources: []string{resource},
 					Verbs:     newVerbs,
@@ -138,7 +167,7 @@ func ExpandPolicyRules(inputRules []rbacv1.PolicyRule) []rbacv1.PolicyRule {
 				rules = append(rules, newRule)
 			}
 		} else {
-			var tmpRule rbacv1.PolicyRule
+			var tmpRule v1.PolicyRule
 			copier.Copy(&tmpRule, &rule)
 			rules = append(rules, tmpRule)
 		}
@@ -146,9 +175,14 @@ func ExpandPolicyRules(inputRules []rbacv1.PolicyRule) []rbacv1.PolicyRule {
 	return rules
 }
 
+// MergeExpandedPolicyRules takes two expanded rulesets (see func `ExpandPolicyRules`) and returns one merged expanded ruleset
+func MergeExpandedPolicyRules(first []v1.PolicyRule, second []v1.PolicyRule) []v1.PolicyRule {
+	return irToPolicyList(unionIRs(policyListToIR(first), policyListToIR(second)))
+}
+
 // APIResourcesToExpandedRules converts an APIResourceList into a list of PolicyRules with all verbs allowed
-func APIResourcesToExpandedRules(resourceLists []*metav1.APIResourceList) []rbacv1.PolicyRule {
-	policyRules := make([]rbacv1.PolicyRule, 0, 100)
+func APIResourcesToExpandedRules(resourceLists []*metav1.APIResourceList) []v1.PolicyRule {
+	outputIR := make(policyListIR)
 
 	for _, resourceList := range resourceLists {
 		for _, resource := range resourceList.APIResources {
@@ -160,20 +194,25 @@ func APIResourcesToExpandedRules(resourceLists []*metav1.APIResourceList) []rbac
 			if len(resource.Verbs) > 0 {
 				copier.Copy(&verbs, &resource.Verbs)
 			}
-			policyRules = append(policyRules, rbacv1.PolicyRule{
-				APIGroups: []string{group},
-				Resources: []string{resource.Name},
-				Verbs:     verbs,
-			})
+			currentPolicyKey := expandedPolicyKey{
+				APIGroup: group,
+				Resource: resource.Name,
+			}
+			if _, ok := outputIR[currentPolicyKey]; ok {
+				// We do this so that we don't generate multiple policy rules for a resource that exists as multiple versions - i.e. v1alpha1, v1beta1, etc.
+				outputIR[currentPolicyKey] = appendSet(outputIR[currentPolicyKey], verbs...)
+			} else {
+				outputIR[currentPolicyKey] = verbs
+			}
 		}
 	}
 
-	return policyRules
+	return irToPolicyList(outputIR)
 }
 
 // ApplyDenyRulesToExpandedRuleset takes in an expanded ruleset (see func `ExpandPolicyRules`) and removes anything matching the deny rules
-func ApplyDenyRulesToExpandedRuleset(fullRuleSet []rbacv1.PolicyRule, denyRules []rbacv1.PolicyRule) []rbacv1.PolicyRule {
-	outputRules := []rbacv1.PolicyRule{}
+func ApplyDenyRulesToExpandedRuleset(fullRuleSet []v1.PolicyRule, denyRules []v1.PolicyRule) []v1.PolicyRule {
+	outputIR := policyListToIR(fullRuleSet)
 
 	for _, rule := range fullRuleSet {
 		for _, denyRule := range denyRules {
@@ -189,22 +228,28 @@ func ApplyDenyRulesToExpandedRuleset(fullRuleSet []rbacv1.PolicyRule, denyRules 
 				denyRuleApplies = true
 			}
 			if denyRuleApplies {
+				currentPolicyKey := expandedPolicyKey{
+					APIGroup: rule.APIGroups[0],
+					Resource: rule.Resources[0],
+				}
 				if !stringInSlice(denyRule.Verbs, "*") {
 					newVerbs = subtractStringSlices(rule.Verbs, denyRule.Verbs)
 					if len(newVerbs) > 0 {
-						var tmpRule rbacv1.PolicyRule
+						var tmpRule v1.PolicyRule
 						copier.Copy(&tmpRule, &rule)
 						tmpRule.Verbs = newVerbs
-						outputRules = append(outputRules, tmpRule)
+						outputIR[currentPolicyKey] = newVerbs
+					} else {
+						delete(outputIR, currentPolicyKey)
 					}
+				} else {
+					delete(outputIR, currentPolicyKey)
 				}
-			} else {
-				outputRules = append(outputRules, rule)
 			}
 		}
 	}
 
-	return outputRules
+	return irToPolicyList(outputIR)
 }
 
 // StripNonResourceURLs takes a list of PolicyRules that may specify NonResourceURLs and returns the same list without any NonResourceURLs
@@ -220,10 +265,10 @@ func StripNonResourceURLs(rules []v1.PolicyRule) []v1.PolicyRule {
 	return rules[:ln]
 }
 
-func ruleHasGroupWildcard(rule *rbacv1.PolicyRule) bool {
+func ruleHasGroupWildcard(rule *v1.PolicyRule) bool {
 	return stringInSlice(rule.APIGroups, "*")
 }
 
-func ruleHasResourceWildcard(rule *rbacv1.PolicyRule) bool {
+func ruleHasResourceWildcard(rule *v1.PolicyRule) bool {
 	return stringInSlice(rule.Resources, "*")
 }


### PR DESCRIPTION
This PR:
- adds the concept of policy rule "internal representation", which is a data structure that's easier to patch and manipulate before converting back to standard policy rules for output to the cluster
- adds support for merging policy rules by their internal representations, which:
  - enables inheriting from multiple roles
  - enables support for explicitly allowed rules (`spec.allow`)
- fixes a bug that could cause duplicate rules to be generated when the same resource is available in the cluster in multiple versions (`v1alpha1` & `v1beta1`, for example)
- fixes a bug in deny rules that could cause duplicate rules to be generated
- fixes a bug where `verbs: ["*"]` would not be enumerated to a list of individual verbs correctly in some situations
- removes "known issues" from readme, since this should be handled with GitHub issues