### PR TITLE
Add dependabot for github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"


### PR DESCRIPTION
This PR configures Dependabot to open up issues if we're using an outdated GH Action. Results of that can be seen here: https://github.com/tylerauerbeck/charts-3/pull/1